### PR TITLE
Fix support for null pointers

### DIFF
--- a/src/cffi_pointer_type.cpp
+++ b/src/cffi_pointer_type.cpp
@@ -22,18 +22,22 @@ bool CFFIPointerType::data_to_variant(const uint8_t *ptr, Variant& r_variant) co
 
 bool CFFIPointerType::variant_to_data(const Variant& value, uint8_t *buffer) const {
 	switch (value.get_type()) {
+		case Variant::Type::NIL:
+			*(const uint8_t **) buffer = nullptr;
+			return true;
+
 		case Variant::Type::PACKED_BYTE_ARRAY: {
 			PackedByteArray bytes = value;
 			*(const uint8_t **) buffer = bytes.ptr();
 			return true;
 		}
 
-		case Variant::Type::OBJECT: {
+		case Variant::Type::OBJECT:
 			if (auto pointer_value = Object::cast_to<CFFIPointer>(value)) {
 				*(uint8_t **) buffer = pointer_value->address_offset_by(0);
 				return true;
 			}
-		}
+			break;
 
 		default:
 			break;

--- a/src/cffi_pointer_type.cpp
+++ b/src/cffi_pointer_type.cpp
@@ -16,7 +16,12 @@ Ref<CFFIType> CFFIPointerType::get_element_type() const {
 
 bool CFFIPointerType::data_to_variant(const uint8_t *ptr, Variant& r_variant) const {
 	uint8_t *value = *(uint8_t **) ptr;
-	r_variant = memnew(CFFIPointer(element_type, value));
+	if (value) {
+		r_variant = memnew(CFFIPointer(element_type, value));
+	}
+	else {
+		r_variant = nullptr;
+	}
 	return true;
 }
 

--- a/src/cffi_type.cpp
+++ b/src/cffi_type.cpp
@@ -93,10 +93,10 @@ bool CFFIType::data_to_variant(const uint8_t *ptr, Variant& r_variant) const {
 			break;
 
 		case FFI_TYPE_STRUCT:
-			ERR_FAIL_V_EDMSG(false, "Struct type is not supported yet");
+			ERR_FAIL_V_EDMSG(false, "Struct type is not supported");
 
 		case FFI_TYPE_POINTER:
-			ERR_FAIL_V_EDMSG(false, "Pointer type is not supported yet");
+			ERR_FAIL_V_EDMSG(false, "Pointer type is not supported");
 
 		case FFI_TYPE_COMPLEX:
 			ERR_FAIL_V_EDMSG(false, "Complex type is not supported yet");
@@ -166,10 +166,10 @@ bool CFFIType::variant_to_data(const Variant& value, uint8_t *buffer) const {
 			break;
 
 		case FFI_TYPE_STRUCT:
-			ERR_FAIL_V_EDMSG(false, "Struct type is not supported yet");
+			ERR_FAIL_V_EDMSG(false, "Struct type is not supported");
 
 		case FFI_TYPE_POINTER:
-			ERR_FAIL_V_EDMSG(false, "Pointer type is not supported yet");
+			ERR_FAIL_V_EDMSG(false, "Pointer type is not supported");
 
 		case FFI_TYPE_COMPLEX:
 			ERR_FAIL_V_EDMSG(false, "Complex type is not supported yet");


### PR DESCRIPTION
- `null` is now accepted as parameters to functions that expect a pointer value
- `null` is now returned instead of a `CFFIPointer` when a function returns null